### PR TITLE
New feature: ac_create_decoder_ex with codecctx callback

### DIFF
--- a/src/acinerella.h
+++ b/src/acinerella.h
@@ -408,6 +408,23 @@ EXTERN lp_ac_decoder CALL_CONVT
     ac_create_decoder(lp_ac_instance pacInstance, int nb);
 
 /**
+ * Callback function used to configure the codec context (AVCodecContext *).
+ * The return value 0 indicates failure, 1 indicates success.
+ */
+typedef int (CALL_CONVT *ac_codecctx_callback)(void *codecctx);
+
+/**
+ * Creates an decoder for the specified stream number. Returns NULL if no
+ * decoder could be found or some other error occurred.
+ *
+ * @param codec_proc is a function that will get called with the
+ * decoder's codec context (AVCodecContext *). May be NULL.
+ */
+EXTERN lp_ac_decoder CALL_CONVT
+    ac_create_decoder_ex(lp_ac_instance pacInstance, int nb,
+                         ac_codecctx_callback codec_proc);
+
+/**
  * Frees an created decoder.
  */
 EXTERN void CALL_CONVT ac_free_decoder(lp_ac_decoder pDecoder);


### PR DESCRIPTION
The rationale for this callback is to enable code to adjust the codecctx settings. For example some users might want to change codecctx error_concealment, err_recognition and skip_loop_filter attributes.

Upside: It's a new function and the existing API remains untouched.
Downside: Exposes some ffmpeg internals via the acinerella API. Also, the pointer type is void * since I didn't want to pull the <avcodec.h> there. So caller is responsible for the necessary casting.