### PR TITLE
read and seek fixes

### DIFF
--- a/src/acinerella.h
+++ b/src/acinerella.h
@@ -1,6 +1,7 @@
 /*
  * Acinerella -- ffmpeg Wrapper Library
  * Copyright (C) 2008-2018  Andreas Stöckel
+ * Copyright (C) 2018  Harry Sintonen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
io_read: fixed a bogus return value when data was returned from probe buffer *and* with read_proc
io_seek: throw away the probe buffer is seek is performed

Without these fixes io_read could return bogus return value, leading to some data being missed by the caller. I didn't observe the io_seek problem in real world, but lets fix that potential issue before it ever surfaces.